### PR TITLE
Add 'verify' command

### DIFF
--- a/lib/Whim/Command/query.pm
+++ b/lib/Whim/Command/query.pm
@@ -14,10 +14,9 @@ my $whim;
 sub run {
     my ( $self, @args ) = @_;
     GetOptionsFromArray(
-        \@args,    \%options,   'before=s', 'after=s',
-        'on=s',    'source=s@', 'target=s', 'not-source=s@',
-        'process', 'count',     'block',    'list',
-        'unblock',
+        \@args,  \%options,   'before=s', 'after=s',
+        'on=s',  'source=s@', 'target=s', 'not-source=s@',
+        'count', 'block',     'list',     'unblock',
     );
 
     massage_options();
@@ -57,17 +56,6 @@ sub run {
 
     if ( $options{count} ) {
         say "Matching webmentions: " . scalar @wms;
-    }
-    elsif ( $options{process} ) {
-        if (@wms) {
-            say "Verifying " . scalar @wms . " webmentions...";
-            my $verified_count = $whim->process_webmentions;
-            my $s              = $verified_count == 1 ? '' : 's';
-            say "\n$verified_count webmention${s} passed verification.";
-        }
-        else {
-            say "No unverified webmentions to process.";
-        }
     }
     else {
         display_wms(@wms);

--- a/lib/Whim/Command/verify.pm
+++ b/lib/Whim/Command/verify.pm
@@ -1,0 +1,35 @@
+package Whim::Command::verify;
+use Mojo::Base 'Mojolicious::Command';
+
+use feature 'signatures';
+no warnings qw(experimental::signatures);
+
+has description => 'Verify webmentions';
+has usage       => "XXX Fill me in! XXX";
+
+use Getopt::Long qw(GetOptionsFromArray);
+my %options;
+my $whim;
+
+sub run {
+    my ( $self, @args ) = @_;
+    GetOptionsFromArray( \@args, \%options, 'quiet', );
+
+    my $results_ref = $self->app->whim->process_webmentions;
+    my ( $verified_count, $total_count ) = $results_ref->@*;
+    if ($total_count) {
+        my $s = $total_count == 1 ? '' : 's';
+        speak(    "$verified_count of $total_count webmention${s} "
+                . "passed verification." );
+    }
+    else {
+        speak("No unverified webmentions to process.");
+    }
+}
+
+sub speak {
+    my ($utterance) = @_;
+    say $utterance unless $options{quiet};
+}
+
+1;

--- a/lib/Whim/Core.pm
+++ b/lib/Whim/Core.pm
@@ -199,6 +199,7 @@ sub fetch_webmentions ( $self, $args ) {
 # process_webmentions: Verify all untested WMs.
 sub process_webmentions( $self ) {
     my $verified_count = 0;
+    my $total_count    = 0;
     my $sth            = $self->dbh->prepare(
               'update wm set is_tested = 1, is_verified = ?, '
             . 'author_name = ?, author_url = ?, author_photo = ?, '
@@ -207,6 +208,7 @@ sub process_webmentions( $self ) {
             . 'where source = ? and target = ? and time_received = ?' );
 
     for my $wm ( $self->fetch_webmentions( { process => 1 } ) ) {
+        $total_count++;
 
         # Grab the author image
         if ( $wm->author && $wm->author->photo ) {
@@ -243,7 +245,7 @@ sub process_webmentions( $self ) {
             $sth->execute( 0, @bind_values );
         }
     }
-    return $verified_count;
+    return [ $verified_count, $total_count ];
 }
 
 # Receive_webmention: Treat the given wm as just-received, untested, unverified.

--- a/t/core.t
+++ b/t/core.t
@@ -46,7 +46,7 @@ my $whim = Whim::Core->new(
 {
     diag("Webmention verification");
     my $count = $whim->process_webmentions;
-    is( $count, 7, "Processed expected number of stored webmentions." );
+    is( $count->[0], 7, "Processed expected number of stored webmentions." );
 
     $count = $whim->fetch_webmentions( {} );
 


### PR DESCRIPTION
This refactors command-line wm verification from `whim query --process` to `whim verify`. Includes a `--quiet` option.

I started to write a test for this but got stopped short when I realized that the way I'd normally test this -- making a system call, then poking at databases to see what it did -- wouldn't work, since that'd run as a separate process which wouldn't share the in-memory database that we use for testing now... right?

I did see e.g. https://metacpan.org/pod/Test::Mojo::CommandOutputRole as a possible way out, but I feared yak shaving, and so am just issuing this PR instead with a question to my expert council about whether it's enough to test functions, and leave surface-level stuff like this untested, at least for now.