### PR TITLE
Multiple send

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires "FindBin";
 requires "LWP::UserAgent";
 requires "Mojolicious";
 requires "Moo";
+requires "MooX::ClassAttribute";
 requires "Path::Tiny";
 requires "Readonly";
 requires "Scalar::Util";

--- a/lib/Whim/Command/send.pm
+++ b/lib/Whim/Command/send.pm
@@ -46,12 +46,8 @@ sub _send_many_wms ( $self, $source ) {
         @wms = Whim::Mention->new_from_source($source);
     }
     catch {
-        if (/lacks/) {
-            chomp;
-            say "Can't determine the content of the source document, so "
-                . "declining to send any webmentions. ($_)";
-        }
-        return;
+        chomp;
+        say "Cannot send any webmentions: $_";
     };
 
     my $success_count = 0;

--- a/lib/Whim/Command/send.pm
+++ b/lib/Whim/Command/send.pm
@@ -4,7 +4,8 @@ use Mojo::Base 'Mojolicious::Command';
 use feature 'signatures';
 no warnings qw(experimental::signatures);
 
-use Web::Mention;
+use Whim::Mention;
+use Try::Tiny;
 
 has description => 'Send webmentions';
 has usage       => "XXX Fill me in! XXX";
@@ -14,9 +15,19 @@ sub run {
 
     $source = check_argument( source => $source );
 
-    $target = check_argument( target => $target );
+    $target = check_argument( target => $target ) if defined $target;
 
-    my $wm = Web::Mention->new( { source => $source, target => $target } );
+    if ( defined $target ) {
+        return $self->_send_one_wm( $source, $target );
+    }
+    else {
+        return $self->_send_many_wms( $source );
+    }
+}
+
+sub _send_one_wm( $self, $source, $target ) {
+
+    my $wm = Whim::Mention->new( { source => $source, target => $target } );
 
     my $success = $wm->send;
 
@@ -28,9 +39,40 @@ sub run {
     }
 }
 
+sub _send_many_wms( $self, $source ) {
+
+    my @wms;
+    try {
+        @wms = Whim::Mention->new_from_source( $source );
+    }
+    catch {
+        if (/lacks/) {
+            chomp;
+            say "Can't determine the content of the source document, so "
+                . "declining to send any webmentions. ($_)";
+        }
+        return;
+    };
+
+    my $success_count = 0;
+    for my $wm (@wms) {
+        if ( $wm->send ) {
+            $success_count++;
+        }
+    }
+
+    my $attempt_count = scalar(@wms);
+
+    my $attempt_s = $attempt_count == 1? '' : 's';
+    my $success_s = $success_count == 1? '' : 's';
+
+    say "Sent $success_count webmention$success_s "
+        . "(from $attempt_count attempt$attempt_s)";
+}
+
 sub check_argument ( $argument_name, $url_text ) {
     unless ( defined $url_text ) {
-        die "Usage: $0 source-url target-url\n";
+        die "Usage: $0 source-url [target-url]\n";
     }
     my $url = URI->new($url_text)
         or die

--- a/lib/Whim/Command/send.pm
+++ b/lib/Whim/Command/send.pm
@@ -21,11 +21,11 @@ sub run {
         return $self->_send_one_wm( $source, $target );
     }
     else {
-        return $self->_send_many_wms( $source );
+        return $self->_send_many_wms($source);
     }
 }
 
-sub _send_one_wm( $self, $source, $target ) {
+sub _send_one_wm ( $self, $source, $target ) {
 
     my $wm = Whim::Mention->new( { source => $source, target => $target } );
 
@@ -39,11 +39,11 @@ sub _send_one_wm( $self, $source, $target ) {
     }
 }
 
-sub _send_many_wms( $self, $source ) {
+sub _send_many_wms ( $self, $source ) {
 
     my @wms;
     try {
-        @wms = Whim::Mention->new_from_source( $source );
+        @wms = Whim::Mention->new_from_source($source);
     }
     catch {
         if (/lacks/) {
@@ -63,8 +63,8 @@ sub _send_many_wms( $self, $source ) {
 
     my $attempt_count = scalar(@wms);
 
-    my $attempt_s = $attempt_count == 1? '' : 's';
-    my $success_s = $success_count == 1? '' : 's';
+    my $attempt_s = $attempt_count == 1 ? '' : 's';
+    my $success_s = $success_count == 1 ? '' : 's';
 
     say "Sent $success_count webmention$success_s "
         . "(from $attempt_count attempt$attempt_s)";

--- a/lib/Whim/Mention.pm
+++ b/lib/Whim/Mention.pm
@@ -1,7 +1,10 @@
 package Whim::Mention;
 
 use Moo;
+use MooX::ClassAttribute;
 extends 'Web::Mention';
+
+use Web::Microformats2::Parser;
 
 has 'author_photo_hash' => (
     is  => 'rw',
@@ -11,5 +14,31 @@ has 'author_photo_hash' => (
         }
     },
 );
+
+class_has 'mf2_parser' => (
+    is => 'ro',
+    default => sub { Web::Microformats2::Parser->new },
+);
+
+sub new_from_source {
+    my ( $class, $source ) = @_;
+
+    my $response = $class->ua->get( $source );
+
+    if ( $response->is_success ) {
+        my $mf2_doc = $class->mf2_parser->parse( $response->content, ( url_context => $source ) );
+        my $entry = $mf2_doc->get_first( 'entry' );
+        my $content = $entry->get_property( 'content' ) if $entry;
+        if ( $content ) {
+            return $class->new_from_html( source => $source, html => $content->{html} );
+        }
+        else {
+            die "Content at $source lacks an h-entry microformat with an e-content property.\n";
+        }
+    }
+    else {
+        die "Could not fetch content from $source: " . $response->status_line . "\n";
+    }
+}
 
 1;

--- a/lib/Whim/Mention.pm
+++ b/lib/Whim/Mention.pm
@@ -16,28 +16,34 @@ has 'author_photo_hash' => (
 );
 
 class_has 'mf2_parser' => (
-    is => 'ro',
+    is      => 'ro',
     default => sub { Web::Microformats2::Parser->new },
 );
 
 sub new_from_source {
     my ( $class, $source ) = @_;
 
-    my $response = $class->ua->get( $source );
+    my $response = $class->ua->get($source);
 
     if ( $response->is_success ) {
-        my $mf2_doc = $class->mf2_parser->parse( $response->content, ( url_context => $source ) );
-        my $entry = $mf2_doc->get_first( 'entry' );
-        my $content = $entry->get_property( 'content' ) if $entry;
-        if ( $content ) {
-            return $class->new_from_html( source => $source, html => $content->{html} );
+        my $mf2_doc = $class->mf2_parser->parse( $response->content,
+            ( url_context => $source ) );
+        my $entry   = $mf2_doc->get_first('entry');
+        my $content = $entry->get_property('content') if $entry;
+        if ($content) {
+            return $class->new_from_html(
+                source => $source,
+                html   => $content->{html}
+            );
         }
         else {
-            die "Content at $source lacks an h-entry microformat with an e-content property.\n";
+            die
+                "Content at $source lacks an h-entry microformat with an e-content property.\n";
         }
     }
     else {
-        die "Could not fetch content from $source: " . $response->status_line . "\n";
+        die "Could not fetch content from $source: "
+            . $response->status_line . "\n";
     }
 }
 

--- a/t/mention.t
+++ b/t/mention.t
@@ -16,16 +16,15 @@ use Path::Tiny;
     diag("Send lots of webmentions based on one page");
 
     my $wm_file = path("$FindBin::Bin/source/many_wms.html");
-    my @wms = Whim::Mention->new_from_source(
-        'file://' . $wm_file->absolute,
-    );
+    my @wms =
+        Whim::Mention->new_from_source( 'file://' . $wm_file->absolute, );
 
-    is (scalar @wms, 6, "Extracted expected webmentions from source doc.");
+    is( scalar @wms, 6, "Extracted expected webmentions from source doc." );
 
     throws_ok(
-        sub{
+        sub {
             my $wm_file = path("$FindBin::Bin/source/no_content.html");
-            my @wms = Whim::Mention->new_from_source(
+            my @wms     = Whim::Mention->new_from_source(
                 'file://' . $wm_file->absolute,
             );
         },

--- a/t/mention.t
+++ b/t/mention.t
@@ -1,0 +1,37 @@
+# Tests specific to Whim::Mention, absent the rest of Whim::Core.
+
+use warnings;
+use strict;
+use v5.20;
+
+use Test::More;
+use Test::Exception;
+use FindBin;
+
+use lib "$FindBin::Bin/../lib";
+use Whim::Mention;
+use Path::Tiny;
+
+{
+    diag("Send lots of webmentions based on one page");
+
+    my $wm_file = path("$FindBin::Bin/source/many_wms.html");
+    my @wms = Whim::Mention->new_from_source(
+        'file://' . $wm_file->absolute,
+    );
+
+    is (scalar @wms, 6, "Extracted expected webmentions from source doc.");
+
+    throws_ok(
+        sub{
+            my $wm_file = path("$FindBin::Bin/source/no_content.html");
+            my @wms = Whim::Mention->new_from_source(
+                'file://' . $wm_file->absolute,
+            );
+        },
+        qr/lacks an h-entry microformat with an e-content property/,
+        "Correctly refused to extract wms from souce doc with no e-content.",
+    );
+}
+
+done_testing();

--- a/t/source/no_content.html
+++ b/t/source/no_content.html
@@ -3,11 +3,16 @@
 <title>This page contains links with various microformats attached.</title>
 </head>
 
+<!--
+This page is like many_wms.html, but it has no e-content microformat.
+Trying to mass-fetch webmentions from it via Whim::Mention->new_from_source
+should throw an exception.
+-->
+
 <div class="h-entry">
 
 <p class="h-card p-author">Some links by <span class="p-name">Alice Nobody</span>.<data class="u-url" value="http://alice.example"></data><data class="u-photo" value="edith.jpg"></data></p>
 
-<div class="e-content">
 <p>
 <a href="http://example.com/reply-target" class="u-in-reply-to">A reply.</a>
 </p>
@@ -31,7 +36,6 @@
 <p>
 <a href="http://example.com/repost-target" class="u-repost-of">A repost.</a>
 </p>
-</div> <!-- end of e-content div -->
 
 <div class="h-cite u-in-reply-to">
     <p><a class="p-author h-card">Edith Example</a>


### PR DESCRIPTION
This adds support for calling `whim send` with one argument.

If called with one argument, the `send` command will:

1. Attempt to fetch the document at the given URL, and present an error message if it can't

1. Attempt to extract an `e-content` property from the first `h-entry` microformat found there, and present an error message if it can't

1. Attempt to send webmentions to all valid candidate URLs found within the fetched content, and report as to how many webmentions it successfully sent out of how many candidates.

The two-argument call continues to function as it did before.