### PR TITLE
Adding a couple of unique constraints to the database creation statements

### DIFF
--- a/lib/Whim/Core.pm
+++ b/lib/Whim/Core.pm
@@ -305,7 +305,9 @@ sub _process_author_photo_tx ( $self, $response ) {
 sub _initialize_database( $dbh ) {
     my @statements = (
         "CREATE TABLE wm (source char(128), original_source char(128), target char(128), time_received text, is_verified int, is_tested int, html text, content text, time_verified text, type char(16), author_name char(64), author_url char(128), author_photo char(128), author_photo_hash char(128), title char(255))",
+        "CREATE UNIQUE INDEX source_target on wm(source, target)",
         "CREATE TABLE block (source char(128))",
+        "CREATE UNIQUE INDEX source on block(source)",
     );
 
     foreach (@statements) {


### PR DESCRIPTION
This addresses #21.

Adds two more SQL commands to the database-setup method in Whim::Core, enforcing uniqueness of source strings in the block table, and source/target tuples in the wm table.

If I understand SQLite's docs correctly, then it automatically gives every table a `rowid` table filled with unique integers (unless you ask it not to), and that this acts as a perfectly good primary key as-is. (Furthermore, if you declare an INT column as a primary key, SQLite will just make it an alias to `rowid`.) So that need is already met, without any changes.