### PR TITLE
Add 'listen' command

### DIFF
--- a/lib/Whim/Command/listen.pm
+++ b/lib/Whim/Command/listen.pm
@@ -2,10 +2,9 @@ package Whim::Command::listen;
 use Mojo::Base 'Mojolicious::Command';
 
 use Mojo::Server::Hypnotoad;
-use Mojo::Util qw(getopt);
 
-has description => 'bleep';
-has usage       => sub { shift->extract_usage };
+has description => 'Listen for incoming webmentions (and other HTTP requests)';
+has usage       => 'XXX Fill me in later XXX';
 
 use Getopt::Long qw(GetOptionsFromArray);
 my %options;

--- a/lib/Whim/Command/listen.pm
+++ b/lib/Whim/Command/listen.pm
@@ -3,8 +3,9 @@ use Mojo::Base 'Mojolicious::Command';
 
 use Mojo::Server::Hypnotoad;
 
-has description => 'Listen for incoming webmentions (and other HTTP requests)';
-has usage       => 'XXX Fill me in later XXX';
+has description =>
+    'Listen for incoming webmentions (and other HTTP requests)';
+has usage => 'XXX Fill me in later XXX';
 
 use Getopt::Long qw(GetOptionsFromArray);
 my %options;

--- a/lib/Whim/Command/listen.pm
+++ b/lib/Whim/Command/listen.pm
@@ -1,0 +1,43 @@
+package Whim::Command::listen;
+use Mojo::Base 'Mojolicious::Command';
+
+use Mojo::Server::Hypnotoad;
+use Mojo::Util qw(getopt);
+
+has description => 'bleep';
+has usage       => sub { shift->extract_usage };
+
+use Getopt::Long qw(GetOptionsFromArray);
+my %options;
+
+sub run {
+    my ( $self, @args ) = @_;
+
+    GetOptionsFromArray( \@args, \%options, qw(foreground help stop test) );
+
+    # The WHIM_HYPNOTOAD environment variable tells the `whim`
+    # executable that it's being run in "Hypnotoad context", adjusting
+    # its default behavior.
+    #
+    # It also tells *this* command, that we shouldn't mess with
+    # Hypnotoad's own environment variables any further.
+
+    unless ( $ENV{WHIM_HYPNOTOAD} ) {
+        foreach (qw(foreground stop test)) {
+            $ENV{ 'HYPNOTOAD_' . uc($_) } = $options{$_};
+        }
+
+        # XXX Nothing for "help" right yet, alas!
+    }
+
+    $ENV{WHIM_HYPNOTOAD} = 1;
+
+    my $toad = Mojo::Server::Hypnotoad->new;
+
+    # XXX Someday, when we have app configuration, we will pass it into
+    #     the $toad server object right around here.
+
+    $toad->run( $self->app->home->child('script')->child('whim') );
+}
+
+1;

--- a/log/.gitignore
+++ b/log/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/script/whim
+++ b/script/whim
@@ -9,5 +9,11 @@ use lib
     ;
 use Mojolicious::Commands;
 
+# This environment variable is set by the `listen` subcommand, and helps
+# tame the Hypnotoad server to suit our hacky purposes.
+if ( $ENV{WHIM_HYPNOTOAD} && !@ARGV ) {
+    @ARGV = ('listen');
+}
+
 # Start command line interface for application
-Mojolicious::Commands->start_app('Whim');
+Mojolicious::Commands->start_app( 'Whim', @ARGV );


### PR DESCRIPTION
This adds a 'listen' command. It just runs Hypnotoad on `whim`. I had to do some hacky business with environment variables to get that to work, but it does seem to do so.

Takes the same arguments as Hypnotoad, and opens the door to feeding Hypnotoad our own config options later, which is nice.

Logs to the new `log/` directory, per Mojo server-setup defaults.

Doesn't actually support its own help option; that's a task for another time (#14)