### PR TITLE
Add command help

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,25 @@ And `prove` for the tests!
 
 ## Running whim
 
-The `whim` executable accepts the following subcommands. Some fine day, they may actually have documentation.
+The `whim` executable accepts the following subcommands. For further documentation and examples, run `whim help [command]`.
 
-- `daemon`: Run a daemon that listens for incoming webmentions and stores them in a local database
+- `listen`: Run a daemon that listens for incoming webmentions and stores them in a local database. (At this time, it only listens on port 8080 - a known bug. See GitHub issue #33.)
+
+    See also ["Displaying webmentions"](#displaying-webmentions), below.
+
 - `send`: Send a webmention
 - `query`: Query a local database for stored webmentions meeting given criteria
+- `verify`: Try to verify every stored webmention with an unknown verification state. (Webmentions do not show up in any queries until they're verified.)
+
+## Displaying webmentions
+
+Besides listening for incoming webmentions, the `listener` command also sets up an HTTP endpont at `/display_wms`. It accepts GET requests that contain one query-string argument, `url`. Whim will fetch and display, as HTML, all verified webmentions whose source matches the given URL.
+
+For example:
+
+    http//example.com:8080/display_wms?url=https://some-source.example/foobar
+
+Whim uses a set of default templates to make this work. You can provide your own templates in `$HOME/.whim/templates`. The fact that I have no further information for you about this is a known issue. (GitHub issue #34)
 
 ## "Whim"?
 

--- a/README.pod
+++ b/README.pod
@@ -72,13 +72,15 @@ And C<prove> for the tests!
 
 =head2 Running whim
 
-The C<whim> executable accepts the following subcommands. Some fine day, they may actually have documentation.
+The C<whim> executable accepts the following subcommands. For further documentation and examples, run C<whim help [command]>.
 
 =over
 
 =item *
 
-C<daemon>: Run a daemon that listens for incoming webmentions and stores them in a local database
+C<listen>: Run a daemon that listens for incoming webmentions and stores them in a local database. (At this time, it only listens on port 8080 - a known bug. See GitHub issue #33.)
+
+See also L<"Displaying webmentions">, below.
 
 
 
@@ -92,10 +94,21 @@ C<send>: Send a webmention
 
 C<query>: Query a local database for stored webmentions meeting given criteria
 
+=item *
 
+C<verify>: Try to verify every stored webmention with an unknown verification state. (Webmentions do not show up in any queries until they're verified.)
 
 =back
 
+=head2 Displaying webmentions
+
+Besides listening for incoming webmentions, the C<listener> command also sets up an HTTP endpont at C</display_wms>. It accepts GET requests that contain one query-string argument, C<url>. Whim will fetch and display, as HTML, all verified webmentions whose source matches the given URL.
+
+For example:
+
+  http//example.com:8080/display_wms?url=https://some-source.example/foobar
+
+Whim uses a set of default templates to make this work. You can provide your own templates in C<$HOME/.whim/templates>. The fact that I have no further information for you about this is a known issue. (GitHub issue #34)
 
 =head2 "Whim"?
 

--- a/lib/Whim.pm
+++ b/lib/Whim.pm
@@ -8,6 +8,8 @@ use Path::Tiny;
 
 our $VERSION = '2020.05.18.00';
 
+has info => "This is Whim, version $VERSION, by Jason McIntosh.";
+
 sub startup {
     my $self = shift;
 
@@ -22,7 +24,8 @@ sub startup {
     my $config =
         $self->plugin( 'Config', { default => { home => $self->home, }, } );
 
-    push @{ $self->commands->namespaces }, 'Whim::Command';
+    $self->commands->namespaces( ['Whim::Command'] );
+    $self->set_up_help;
 
     # Create a 'whim' helper containing our Whim::Core object
     $self->helper(
@@ -54,6 +57,15 @@ sub startup {
 
     $r->get('/display_wms')->to('display#display');
 
+}
+
+sub set_up_help {
+    my $self = shift;
+    $self->commands->message( $self->info . "\n\n" );
+
+    $self->commands->hint(
+        "See '$0 help COMMAND' for more information on a specific commmand.\n"
+    );
 }
 
 1;

--- a/lib/Whim/Command/listen.pm
+++ b/lib/Whim/Command/listen.pm
@@ -7,7 +7,7 @@ use FindBin;
 
 has description =>
     'Listen for incoming webmentions (and other HTTP requests)';
-has usage => 'XXX Fill me in later XXX';
+has usage => sub { shift->extract_usage };
 
 use Getopt::Long qw(GetOptionsFromArray);
 my %options;
@@ -44,3 +44,43 @@ sub run {
 }
 
 1;
+
+=encoding utf8
+
+=head1 NAME
+
+Whim::Command::listen - Listen command
+
+=head1 SYNOPSIS
+
+  Usage: whim listen [OPTIONS]
+
+  Examples:
+    whim listen
+    whim listen --stop
+
+  Options:
+    --stop                  Stop the listener
+    --foreground            Run the listener in the foreground
+
+=head1 DESCRIPTION
+
+This command just runs a L<hypnotoad> instance, configured to use your
+local L<Whim> installation. It will respect any Hypnotoad-specific
+environment variables and other configuration that you might have set.
+
+Logs and pidfiles and such will go into C<$HOME/.whim/>.
+
+This script is currently too stupid to listen to any location other than
+http://*:8080. Hope that's what you want! (See L<"NOTES AND BUGS">.)
+
+=head1 NOTES AND BUGS
+
+This script is extremely preliminary, and actually rather rubbish. Every
+part of it is subject to change.
+
+=head1 SEE ALSO
+
+L<whim>
+
+=cut

--- a/lib/Whim/Command/query.pm
+++ b/lib/Whim/Command/query.pm
@@ -4,8 +4,8 @@ use Mojo::Base 'Mojolicious::Command';
 use feature 'signatures';
 no warnings qw(experimental::signatures);
 
-has description => 'Fetch webmentions';
-has usage       => "XXX Fill me in! XXX";
+has description => 'Fetch and display webmentions, or update your block-list';
+has usage       => sub { shift->extract_usage };
 
 use Getopt::Long qw(GetOptionsFromArray);
 my %options;
@@ -156,3 +156,53 @@ sub massage_options {
 }
 
 1;
+
+=encoding utf8
+
+=head1 NAME
+
+Whim::Command::query - Query command
+
+=head1 SYNOPSIS
+
+  Usage: whim query [OPTIONS]
+
+  The default action is to display a list of stored webmentions, optionally
+  filtered by the provided options. You can run other actions by providing
+  different options, as listed below.
+
+  Options:
+    Actions:
+      --list     Display the current blocklist
+      --block    Add source strings (via --source) to the blocklist
+      --unblock  Remove source strings (via --source) from the blocklist
+
+    Filters:                    Limit affected webmentions to those...
+      --before=2020-01-01          received before this date
+      --after=2020-01-01           received after this date
+      --on=2020-01-01              received on this date exactly
+      --source=example.com/foo     whose source URL contains this string
+      --not-source=example.com/bar whose source URL lacks this string
+      --target=mysite.example/bar  whose target URL contains this string
+
+=head1 DESCRIPTION
+
+This command queries Whim's webmention database, either to display
+summaries of webmentions that meet criteria specified as command-line
+options, or to manage one's blocklist.
+
+You can specify multiple C<--source> or C<--not-source> flags, as needed.
+
+=head1 NOTES AND BUGS
+
+The blocklist-management stuff should really have its own command.
+(GitHub issue #32)
+
+This should be able to output JSON representations of webmentions
+(GitHub issue #8)
+
+=head1 SEE ALSO
+
+L<whim>
+
+=cut

--- a/lib/Whim/Command/send.pm
+++ b/lib/Whim/Command/send.pm
@@ -8,7 +8,7 @@ use Whim::Mention;
 use Try::Tiny;
 
 has description => 'Send webmentions';
-has usage       => "XXX Fill me in! XXX";
+has usage       => sub { shift->extract_usage };
 
 sub run {
     my ( $self, $source, $target ) = @_;
@@ -79,3 +79,35 @@ sub check_argument ( $argument_name, $url_text ) {
 }
 
 1;
+
+=encoding utf8
+
+=head1 NAME
+
+Whim::Command::send - Send command
+
+=head1 SYNOPSIS
+
+  Usage: whim send [source-url] [target-url]
+
+  Run with two arguments to send a single webmention with the given
+  source and target URLs.
+
+  Run with one argument to send webmentions to every valid target found
+  within the content found at the given source URL.
+
+=head1 DESCRIPTION
+
+This command sends webmentions, as described above. It prints a short
+description of what it did to standard output.
+
+If called with one argument, it will attempt to load the content from
+the given source URL, locate an C<h-entry> microformat with an
+C<e-content> property, and then try to send webmentions to all linked
+URLs found within.
+
+=head1 SEE ALSO
+
+L<whim>
+
+=cut

--- a/lib/Whim/Command/verify.pm
+++ b/lib/Whim/Command/verify.pm
@@ -5,7 +5,7 @@ use feature 'signatures';
 no warnings qw(experimental::signatures);
 
 has description => 'Verify webmentions';
-has usage       => "XXX Fill me in! XXX";
+has usage       => sub { shift->extract_usage };
 
 use Getopt::Long qw(GetOptionsFromArray);
 my %options;
@@ -33,3 +33,27 @@ sub speak {
 }
 
 1;
+
+=encoding utf8
+
+=head1 NAME
+
+Whim::Command::verify - Verify command
+
+=head1 SYNOPSIS
+
+  Usage: whim verify
+
+=head1 DESCRIPTION
+
+This command verifies webmentions, as described above. It prints a short
+description of what it did to standard output.
+
+It will automatically limit its work to those webmentions that have not already
+had a verification attempt made on them.
+
+=head1 SEE ALSO
+
+L<whim>
+
+=cut


### PR DESCRIPTION
Adds POD to every command class, and Mojo magic to let the `whim help COMMAND` syntax work for all.

Replaces Mojo's boilerplate help text with Whim-specific information.

Updates the READMEs a bit.

I wrestled more with `whim listen` here and gave up, admitting it's garbage and filing another issue to fix before I can call this usable. (See #33.)

Fixes #14.