### PR TITLE
Allow alternate templates to be named in the query string

### DIFF
--- a/lib/Whim/Controller/Display.pm
+++ b/lib/Whim/Controller/Display.pm
@@ -31,7 +31,19 @@ sub display {
 
     $self->stash->{webmentions}      = \%webmentions;
     $self->stash->{webmention_count} = scalar @webmentions;
-    $self->render('webmentions');
+
+    # Use the template 'webmentions', unless a 't' value is provided, in which
+    # case use that (after a simple taint check)
+    my $template_name = $self->param('t') // 'webmentions';
+    if ( $template_name =~ /[^\-\w\d]/ ) {
+        $self->render(
+            status => $BAD_REQUEST,
+            text   => 'Invalid template name.',
+        );
+        return;
+    }
+
+    $self->render($template_name);
 }
 
 1;

--- a/t/daemon.t
+++ b/t/daemon.t
@@ -42,6 +42,16 @@ $t->app->whim->process_webmentions;
 $t->get_ok('/display_wms?url=http://example.com/like-target')->status_is(200)
     ->content_like(qr/Alice Nobody/);
 
+# Check alternate templates too
+$t->get_ok('/display_wms?url=http://example.com/like-target&t=it_worked')
+    ->status_is(200)->content_like(qr/It worked!/);
+
+$t->get_ok('/display_wms?url=http://example.com/like-target&t=no_template')
+    ->status_is(404);
+
+$t->get_ok('/display_wms?url=http://example.com/like-target&t=/etc/passwd')
+    ->status_is(400);
+
 done_testing();
 
 sub set_up_app {

--- a/t/templates/it_worked.html.ep
+++ b/t/templates/it_worked.html.ep
@@ -1,0 +1,1 @@
+It worked!


### PR DESCRIPTION
In the display controller, if a parameter 't' exists, taint-check its value and then treat it as the name of a template to use other than the default `webmentions`.

Useful for, say, displaying a summary view of webmentions (in a template called 'summary', e.g.), versus the default full-detail view, when displaying a list of posts. Or any other time you want to use a different layout than whatever happens to be in 'webmentions'.

I can't decide if this is a good idea, promoting flexibility, or a terrible idea, because letting the user control what file gets loaded by naming it, even with safeties and limitations attached, is just gross on its face. The other option is just to recognized a "limited vocabulary" of alternate templates (and then pass in "summary=1"), or to expect the user to set up a query-value-to-file mapping themselves, and I don't like those options either.