### PR TITLE
Handle re-sent wms gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data
 .tidyall.d
 public/author_photos/*
+t/source/test_wms.html

--- a/lib/Whim/Core.pm
+++ b/lib/Whim/Core.pm
@@ -299,6 +299,7 @@ sub receive_webmention ( $self, $wm ) {
             $wm->target->as_string,
             $wm->time_received->iso8601,
             0,
+            0,
         );
     }
 }

--- a/lib/Whim/Core.pm
+++ b/lib/Whim/Core.pm
@@ -231,8 +231,9 @@ sub process_webmentions( $self ) {
         # This allows us to update re-sent wms that might have new content
         # (or might be deleted, or otherwise no longer valid).
         my $wm = Whim::Mention->new(
-            {   source => $stored_wm->source,
-                target => $stored_wm->target,
+            {   source        => $stored_wm->source,
+                target        => $stored_wm->target,
+                time_received => $stored_wm->time_received,
             }
         );
 

--- a/t/source/many_wms_minus_one.html
+++ b/t/source/many_wms_minus_one.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<head>
+<title>This page contains links with various microformats attached.</title>
+</head>
+
+<div class="h-entry">
+
+<p class="h-card p-author">Some links by <span class="p-name">Alice Nobody</span>.<data class="u-url" value="http://alice.example"></data><data class="u-photo" value="edith.jpg"></data></p>
+
+<div class="e-content">
+<p>
+<a href="http://example.com/reply-target" class="u-in-reply-to">A reply.</a>
+</p>
+
+<p>
+This used to be a generic mention, but the hyperlink is gone now.
+</p>
+
+<p>
+<a href="http://example.com/quotation-target" class="u-quotation-of">A quotation.</a>
+</p>
+
+<p>
+<a href="http://example.com/like-target" class="u-like-of">A like.</a>
+</p>
+
+<p>
+<a href="http://example.com/some-other-target" class="u-like-of">A like of some other target, just to spice things up.</a>
+</p>
+
+<p>
+<a href="http://example.com/repost-target" class="u-repost-of">A repost.</a>
+</p>
+</div> <!-- end of e-content div -->
+
+<div class="h-cite u-in-reply-to">
+    <p><a class="p-author h-card">Edith Example</a>
+    <a class="u-url" href="http://example.com/another-reply-target"></a></p>
+    <p>Another reply, but this time with its referent URL in an h-cite item. And it's also outside of the entry's e-content div!</p>
+</div>
+
+<p>
+Hooray!
+</p>
+
+</div> <!-- end of h-entry div -->


### PR DESCRIPTION
1. On receipt of a wm with the same source+target as a wm already in storage, mark the stored one as untested, and therefore due for re-verification. Keep its verification status and all other attributes as they are (so, in effect, don't immediately yank an already-valid vm offline as soon as a duplicate is received).

1. Base the verification of any wm on a fresh, minimal copy of that wm. This lets Web::Mention re-load all of its attributes from its fetched source content every time.

Fixes #22.