### PR TITLE
One-argument `whim send` now tries all the targets

### DIFF
--- a/lib/Whim/Command/send.pm
+++ b/lib/Whim/Command/send.pm
@@ -16,12 +16,9 @@ sub run {
     my ( $self, @args ) = @_;
 
     my $limit_to_entry = 0;
-    getopt (
-        \@args,
-        'e|entry' => sub { $limit_to_entry = 1 },
-    );
+    getopt( \@args, 'e|entry' => sub { $limit_to_entry = 1 }, );
 
-    my ($source, $target) = @args;
+    my ( $source, $target ) = @args;
 
     warn "I have $source and $target with $limit_to_entry.";
 
@@ -33,7 +30,7 @@ sub run {
         return $self->_send_one_wm( $source, $target );
     }
     else {
-        return $self->_send_many_wms($source, $limit_to_entry);
+        return $self->_send_many_wms( $source, $limit_to_entry );
     }
 }
 
@@ -55,10 +52,8 @@ sub _send_many_wms ( $self, $source, $limit_to_entry ) {
 
     my @wms;
     try {
-        @wms = Whim::Mention->new_from_source(
-            $source,
-            limit_to_entry => $limit_to_entry,
-        );
+        @wms = Whim::Mention->new_from_source( $source,
+            limit_to_entry => $limit_to_entry, );
     }
     catch {
         chomp;

--- a/lib/Whim/Mention.pm
+++ b/lib/Whim/Mention.pm
@@ -27,10 +27,10 @@ sub new_from_source {
 
     if ( $response->is_success ) {
         my $html;
-        if ($options{limit_to_entry}) {
+        if ( $options{limit_to_entry} ) {
             my $mf2_doc = $class->mf2_parser->parse( $response->content,
                 ( url_context => $source ) );
-            my $entry   = $mf2_doc->get_first('entry');
+            my $entry = $mf2_doc->get_first('entry');
             if ($entry) {
                 $html = $entry->{html};
             }

--- a/t/mention.t
+++ b/t/mention.t
@@ -19,17 +19,17 @@ use Path::Tiny;
     my @wms =
         Whim::Mention->new_from_source( 'file://' . $wm_file->absolute, );
 
-    is( scalar @wms, 6, "Extracted expected webmentions from source doc." );
+    is( scalar @wms, 7, "Extracted expected webmentions from source doc." );
 
     throws_ok(
         sub {
-            my $wm_file = path("$FindBin::Bin/source/no_content.html");
+            my $wm_file = path("$FindBin::Bin/source/no_entry.html");
             my @wms     = Whim::Mention->new_from_source(
                 'file://' . $wm_file->absolute,
-            );
+                limit_to_entry => 1, );
         },
-        qr/lacks an h-entry microformat with an e-content property/,
-        "Correctly refused to extract wms from souce doc with no e-content.",
+        qr/lacks an h-entry microformat/,
+        "Correctly refused to extract wms from souce doc with no h-entry.",
     );
 }
 

--- a/t/source/no_entry.html
+++ b/t/source/no_entry.html
@@ -4,12 +4,10 @@
 </head>
 
 <!--
-This page is like many_wms.html, but it has no e-content microformat.
+This page is like many_wms.html, but it has no h-entry microformat.
 Trying to mass-fetch webmentions from it via Whim::Mention->new_from_source
-should throw an exception.
+with the "limit_to_entry" option enabled should throw an exception.
 -->
-
-<div class="h-entry">
 
 <p class="h-card p-author">Some links by <span class="p-name">Alice Nobody</span>.<data class="u-url" value="http://alice.example"></data><data class="u-photo" value="edith.jpg"></data></p>
 
@@ -46,5 +44,3 @@ should throw an exception.
 <p>
 Hooray!
 </p>
-
-</div> <!-- end of h-entry div -->


### PR DESCRIPTION
Calling `whim send` with one argument will now attempt to send a webmention to every valid target anywhere on the source document.

This also adds support for an `--entry` command-line option that limits this to the first `h-entry` on the page.

Limiting the targets to the first `h-entry`'s `content` property -- the command's current behavior -- is simply incorrect, and has been removed entirely.

Fixes #51.