### PR TITLE
Add missing newline in man page

### DIFF
--- a/script/whim
+++ b/script/whim
@@ -108,7 +108,8 @@ unless you remove the relevant blocks from its blocklist.
 
 =head2 listen
 
-    whim listen start whim listen -l http://*:8080 start
+    whim listen start 
+    whim listen -l http://*:8080 start
     whim listen -l 'https://*:3000?cert=./server.crt&key=./server.key' \
          start
     whim listen stop


### PR DESCRIPTION
I'm not 100% sure whether or not you intended for all of that to be on a single line but I'm guessing that there should be a newline there.